### PR TITLE
Allow Twig 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
         - php: 5.6
         - php: 7.0
         - php: 7.1
+        - php: 7.2
+        - php: 7.3
         - php: nightly
     allow_failures:
         - php: nightly

--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@ Simple Pagination Bundle
 
 [![Build Status](https://travis-ci.org/AshleyDawson/SimplePaginationBundle.svg?branch=master)](https://travis-ci.org/AshleyDawson/SimplePaginationBundle)
 
-[![knpbundles.com](http://knpbundles.com/AshleyDawson/SimplePaginationBundle/badge-short)](http://knpbundles.com/AshleyDawson/SimplePaginationBundle)
-
 Symfony 2 bundle for the [Simple Pagination](https://github.com/AshleyDawson/SimplePagination) library.
 
 Installation
 ------------
 
-You can install the Simple Pagination Bundle via [Composer](https://getcomposer.org/). To do that, simply `require` the 
+You can install the Simple Pagination Bundle via [Composer](https://getcomposer.org/). To do that, simply `require` the
 package in your `composer.json` file like so:
 
 ```json
@@ -34,7 +32,7 @@ Basic Usage
 -----------
 
 The simplest collection we can use the paginator service on is an array. Please see below for an extremely
-simple example of the paginator operating on an array. This shows the service paginating over an array of 
+simple example of the paginator operating on an array. This shows the service paginating over an array of
 12 items.
 
 ```php
@@ -109,7 +107,7 @@ And in the twig view, it looks like this:
 ```
 
 You can override the "items per page" and "pages in range" options at runtime by passing values to the paginator like this:
- 
+
 ```php
 // ...
 
@@ -208,9 +206,9 @@ And in the twig view, it looks like this:
 {# Use the pagination view helper to render the page navigation #}
 <div>
     {{ simple_pagination_render(
-        pagination, 
-        '_welcome', 
-        'page', 
+        pagination,
+        '_welcome',
+        'page',
         app.request.query.all
     ) }}
 </div>
@@ -256,10 +254,10 @@ An exhaustive twig view example is as follows:
 ```twig
 <div>
     {{ simple_pagination_render(
-        pagination, 
-        '_welcome', 
-        'page', 
-        app.request.query.all, 
+        pagination,
+        '_welcome',
+        'page',
+        app.request.query.all,
         'AcmeBundle:Default:pagination.html.twig'
     ) }}
 </div>

--- a/Tests/DependencyInjection/AshleyDawsonSimplePaginationExtensionTest.php
+++ b/Tests/DependencyInjection/AshleyDawsonSimplePaginationExtensionTest.php
@@ -6,7 +6,7 @@ use AshleyDawson\SimplePaginationBundle\DependencyInjection\AshleyDawsonSimplePa
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
-class AshleyDawsonSimplePaginationExtensionTest extends \PHPUnit_Framework_TestCase
+class AshleyDawsonSimplePaginationExtensionTest extends \PHPUnit\Framework\TestCase
 {
     public function testLoadWithoutConfiguration()
     {

--- a/Tests/Twig/SimplePaginationExtensionTest.php
+++ b/Tests/Twig/SimplePaginationExtensionTest.php
@@ -4,8 +4,10 @@ namespace AshleyDawson\SimplePaginationBundle\Tests\Twig;
 
 use AshleyDawson\SimplePaginationBundle\Twig\SimplePaginationExtension;
 use AshleyDawson\SimplePagination\Paginator;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
-class SimplePaginationExtensionTest extends \PHPUnit_Framework_TestCase
+class SimplePaginationExtensionTest extends \PHPUnit\Framework\TestCase
 {
     private $pagination;
 
@@ -35,8 +37,8 @@ class SimplePaginationExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testExtension()
     {
-        $loader = new \Twig_Loader_Filesystem(__DIR__.'/../fixtures/views');
-        $twig = new \Twig_Environment($loader);
+        $loader = new FilesystemLoader(__DIR__.'/../fixtures/views');
+        $twig = new Environment($loader);
 
         $extension = new SimplePaginationExtension('default.html.twig');
         $html = $extension->render(
@@ -52,8 +54,8 @@ class SimplePaginationExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testExtensionInTemplate()
     {
-        $loader = new \Twig_Loader_Filesystem(__DIR__.'/../fixtures/views');
-        $twig = new \Twig_Environment($loader);
+        $loader = new FilesystemLoader(__DIR__.'/../fixtures/views');
+        $twig = new Environment($loader);
         $twig->addExtension(new SimplePaginationExtension('default.html.twig'));
 
         $html = $twig->loadTemplate('pagination.html.twig')->render([

--- a/Twig/SimplePaginationExtension.php
+++ b/Twig/SimplePaginationExtension.php
@@ -3,6 +3,9 @@
 namespace AshleyDawson\SimplePaginationBundle\Twig;
 
 use AshleyDawson\SimplePagination\Pagination;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Class SimplePaginationExtension
@@ -10,7 +13,7 @@ use AshleyDawson\SimplePagination\Pagination;
  * @package AshleyDawson\SimplePaginationBundle\Twig
  * @author Ashley Dawson <ashley@ashleydawson.co.uk>
  */
-class SimplePaginationExtension extends \Twig_Extension
+class SimplePaginationExtension extends AbstractExtension
 {
     /**
      * @var string
@@ -33,7 +36,7 @@ class SimplePaginationExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'simple_pagination_render',
                 array($this, 'render'),
                 array(
@@ -47,7 +50,7 @@ class SimplePaginationExtension extends \Twig_Extension
     /**
      * Render the pagination
      *
-     * @param Twig_Environment $environment Will be automatically injected by Twig
+     * @param Environment $environment Will be automatically injected by Twig
      * @param Pagination $pagination
      * @param string $routeName
      * @param string $pageParameterName
@@ -56,7 +59,7 @@ class SimplePaginationExtension extends \Twig_Extension
      * @return string
      */
     public function render(
-        \Twig_Environment $environment, Pagination $pagination, $routeName, $pageParameterName = 'page', array $queryParameters = array(), $template = null)
+        Environment $environment, Pagination $pagination, $routeName, $pageParameterName = 'page', array $queryParameters = array(), $template = null)
     {
         if (null === $template) {
             $template = $this->defaultTemplate;

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "~2.3|~3.0",
-        "twig/twig": "~1.23",
+        "twig/twig": "~1.23|^2.7",
         "ashleydawson/simple-pagination": "1.0.*"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.0"
+        "symfony/phpunit-bridge": "^4.0"
     },
     "autoload": {
         "psr-0": { "AshleyDawson\\SimplePaginationBundle": "" }


### PR DESCRIPTION
Convert old Twig namespace to new one. As they started to be available since Twig 2.7, I defined that version in the `composer.json`.

Also:
- Travis now run PHP 7.2 & 7.3
- Update PHPunit namespace in tests