### PR TITLE
Add support for Symfony 4 & 5

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /vendor
-/bin
 /.idea
 /phpunit.xml
 /composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
+os: linux
+dist: xenial
 language: php
-
-sudo: false
 
 cache:
     apt: true
     directories:
         - $HOME/.composer/cache
 
-matrix:
+jobs:
     fast_finish: true
     include:
-        - php: 5.5
-        - php: 5.6
-        - php: 7.0
-        - php: 7.1
         - php: 7.2
         - php: 7.3
+        - php: 7.4
+        - php: 7.2
+          env: COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
         - php: nightly
     allow_failures:
         - php: nightly
@@ -24,7 +23,7 @@ before_install:
     - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
-    - composer --prefer-dist install --no-interaction -o --no-progress
+    - composer update --prefer-dist --no-progress --no-suggest -o $COMPOSER_FLAGS
 
 script:
-    - ./bin/simple-phpunit -v
+    - ./vendor/bin/simple-phpunit -v

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple Pagination Bundle
 
 Many thanks to [BrowserStack](https://www.browserstack.com/) for supporting open source projects like this one.
 
-Symfony 2 bundle for the [Simple Pagination](https://github.com/AshleyDawson/SimplePagination) library.
+Symfony bundle for the [Simple Pagination](https://github.com/AshleyDawson/SimplePagination) library.
 
 Installation
 ------------

--- a/Tests/Twig/SimplePaginationExtensionTest.php
+++ b/Tests/Twig/SimplePaginationExtensionTest.php
@@ -11,7 +11,7 @@ class SimplePaginationExtensionTest extends \PHPUnit\Framework\TestCase
 {
     private $pagination;
 
-    public function setUp()
+    public function setUp(): void
     {
         $items = array(
             'Banana',
@@ -47,9 +47,9 @@ class SimplePaginationExtensionTest extends \PHPUnit\Framework\TestCase
             ''
         );
 
-        $this->assertContains('<span class="page current">1</span>', $html);
-        $this->assertContains('<span class="page next active">2</span>', $html);
-        $this->assertContains('<span class="page last active">3</span>', $html);
+        $this->assertStringContainsString('<span class="page current">1</span>', $html);
+        $this->assertStringContainsString('<span class="page next active">2</span>', $html);
+        $this->assertStringContainsString('<span class="page last active">3</span>', $html);
     }
 
     public function testExtensionInTemplate()
@@ -58,13 +58,13 @@ class SimplePaginationExtensionTest extends \PHPUnit\Framework\TestCase
         $twig = new Environment($loader);
         $twig->addExtension(new SimplePaginationExtension('default.html.twig'));
 
-        $html = $twig->loadTemplate('pagination.html.twig')->render([
+        $html = $twig->load('pagination.html.twig')->render([
             'app' => ['request' => ['query' => ['all' => []]]],
             'pagination' => $this->pagination,
         ]);
 
-        $this->assertContains('<span class="page current">1</span>', $html);
-        $this->assertContains('<span class="page next active">2</span>', $html);
-        $this->assertContains('<span class="page last active">3</span>', $html);
+        $this->assertStringContainsString('<span class="page current">1</span>', $html);
+        $this->assertStringContainsString('<span class="page next active">2</span>', $html);
+        $this->assertStringContainsString('<span class="page last active">3</span>', $html);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "ashleydawson/simple-pagination-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony2 bundle for Simple Pagination, the simple, lightweight and universal paginator that implements pagination on collections of things",
-    "keywords": ["pagination", "paginator", "pager", "simple", "easy", "flexible", "universal", "lite", "lightweight", "symfony2", "bundle"],
+    "description": "Symfony bundle for Simple Pagination, the simple, lightweight and universal paginator that implements pagination on collections of things",
+    "keywords": ["pagination", "paginator", "pager", "simple", "easy", "flexible", "universal", "lite", "lightweight", "symfony", "bundle"],
     "license": "MIT",
     "authors": [
         {
@@ -11,19 +11,23 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "symfony/symfony": "^3.0|^4.0",
-        "twig/twig": "~1.23|^2.7",
+        "php": "^7.2.5",
+        "symfony/config": "^3.4|^4.2|^5.0",
+        "symfony/dependency-injection": "^3.4|^4.2|^5.0",
+        "symfony/http-kernel": "^3.4|^4.2|^5.0",
+        "symfony/yaml": "^3.4|^4.2|^5.0",
+        "twig/twig": "^2.7|^3.0",
         "ashleydawson/simple-pagination": "1.0.*"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/phpunit-bridge": "^5.0"
     },
     "autoload": {
-        "psr-0": { "AshleyDawson\\SimplePaginationBundle": "" }
-    },
-    "target-dir": "AshleyDawson/SimplePaginationBundle",
-    "config": {
-        "bin-dir": "bin"
+        "psr-4": {
+            "AshleyDawson\\SimplePaginationBundle\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     }
 }


### PR DESCRIPTION
Mostly `composer.json` update to add support for Symfony 4 & 5.

- Drop PHP < 7.2
- Allow Twig 3
- Use psr-4 instead of psr-0

Fix #4